### PR TITLE
Use HTML safe trademark symbol

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         Demos will happen at around 7pm.
       </p>
       <p>
-        There will be some Terrible™ prizes. Categories announced day of.
+        There will be some Terrible&trade; prizes. Categories announced day of.
       </p>
     </section>
     <section id="pricing">
@@ -66,7 +66,7 @@
       <p>Want to sponsor us and be able to upload an image of your choice here? There's a <a href='https://gf.me/u/v9fm2i'>GoFundMe</a>!</p>
     </section>
     <section class="odd" id="8">
-      <h2>Thank you for listening to my Ted Talk™. </h2>Direct questions to our <a href="https://www.facebook.com/terriblehack/">Facebook page</a>
+      <h2>Thank you for listening to my Ted Talk&trade;. </h2>Direct questions to our <a href="https://www.facebook.com/terriblehack/">Facebook page</a>
     </section>
     <script>
       var scroll = new SmoothScroll('a[href*="#"]');


### PR DESCRIPTION
When developing locally, the ™ symbol looked wonky

![image](https://user-images.githubusercontent.com/26397946/67912430-4e43a900-fb60-11e9-972e-076d255ed20e.png)

Switched it to use the HTML safe version 
![image](https://user-images.githubusercontent.com/26397946/67912438-53085d00-fb60-11e9-9e7e-76be01c72864.png)
